### PR TITLE
 fixed fileData name to be correct in the htpasswd_crd.yaml

### DIFF
--- a/authentication_configuration/htpasswd_crd.yaml
+++ b/authentication_configuration/htpasswd_crd.yaml
@@ -9,4 +9,4 @@ spec:
       type: HTPasswd
       htpasswd:
         fileData:
-          name: htpass-secret
+          name: users.htpasswd

--- a/authentication_configuration/htpasswd_crd.yaml
+++ b/authentication_configuration/htpasswd_crd.yaml
@@ -4,9 +4,9 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-    - name: my_htpasswd_provider
+    - name: HTPasswd
       mappingMethod: claim
       type: HTPasswd
       htpasswd:
         fileData:
-          name: users.htpasswd
+          name: htpass-secret


### PR DESCRIPTION
CRD would leave the authentication operator in a degraded state due to the incorrect name in the fileData field.